### PR TITLE
Add link to type-o-rama

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A collection of awesome things regarding Reason/OCaml ecosystem.
 * [bs-loader](https://github.com/reasonml-community/bs-loader) - Webpack loader for Bucklescript
 * [resuggest](https://github.com/GuillaumeSalles/resuggest) - Discover Reason functions based on examples.
 * [rollup-plugin-bucklescript](https://github.com/shrynx/rollup-plugin-bucklescript) - rollup plugin for using bucklescript
+* [type-o-rama](https://github.com/stereobooster/type-o-rama) - JS type systems interportability
 
 #### Reason Libraries/Bindings
 * [Reasonml-community](https://github.com/reasonml-community) - Where some of the community projects live


### PR DESCRIPTION
[type-o-rama](https://github.com/stereobooster/type-o-rama) - JS type systems interportability. It lists tools to convert from ReasonML or to ReasonML.