### PR TITLE
Added ReasonQL: Type-safe and simple GraphQL library and reason-css-modules-loader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A collection of awesome things regarding Reason/OCaml ecosystem.
 * [bs-nice](https://github.com/threepointone/bs-nice) - CSS-in-Reason typed CSS by Sunil Pai ([glamor](https://github.com/threepointone/glamor) author)
 * [flex](https://github.com/jordwalke/flex) - CSS flexbox layout engine in Reason (port of Yoga)
 * [re-classnames](https://github.com/alexfedoseev/re-classnames) - Simple reimplementation of [classnames](https://github.com/JedWatson/classnames) in ReasonML
+* [reason-css-modules-loader](https://github.com/sainthkh/reason-css-modules-loader) - Drop-in replacement for [css-loader](https://github.com/webpack-contrib/css-loader).
 
 #### Reason Editor Plugins
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A collection of awesome things regarding Reason/OCaml ecosystem.
 * [rembrandt](https://github.com/przemyslawjanpietrzak/rembrandt) - Simple functional UI framework written in Reasonml.
 * [ReDate](https://github.com/mobily/re-date) - 📆 A collection of useful helpers for handling dates in ReasonML with the same modern API as the well-known `date-fns`
 * [bs-typing](https://github.com/arecvlohe/bs-typing) - Typed.js bindings
+* [reasonql](https://github.com/sainthkh/reasonql) - Type-safe and simple GraphQL client for ReasonML
 
 #### Reason CSS
 * [bs-react-fela](https://github.com/astrada/bs-react-fela) - Bindings for [fela](https://github.com/rofrischmann/fela)


### PR DESCRIPTION
Hello.

Can I add 2 libraries I created? 

One is a new GraphQL client. It fetches and decodes JSON data we got from GraphQL server to ReasonML records. 

Link to the repo: https://github.com/sainthkh/reasonql.

The other is reason-css-modules-loader. It generates CSS Modules type definition for ReasonML.

Link to the repo: https://github.com/sainthkh/reason-css-modules-loader